### PR TITLE
Specify psql version for VaultWarden

### DIFF
--- a/vaultwarden/docker-compose.yml
+++ b/vaultwarden/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - 4001:80
   vaultwarden-db:
     container_name: vaultwarden-db
-    image: postgres:latest
+    image: postgres:16
     environment:
       - POSTGRES_DB=${VW_DB_DATABASE}
       - POSTGRES_USER=${VW_DB_USERNAME}


### PR DESCRIPTION
This PR makes our version of psql more explicit (we want it linked to what vaultwarden expects, not based on the latest version released)